### PR TITLE
tidied, semi-colons, interpolated strings & grunt < grunt-cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-var interactive = require('./index.js');
-interactive();
+var interactive = require('./index.js')
+interactive()

--- a/index.es6.js
+++ b/index.es6.js
@@ -1,248 +1,125 @@
-import inquirer from 'inquirer'
-import semafor from 'semafor'
-import glue from 'glue-path'
-import packager from 'electron-packager'
-import colors from 'colors'
+import inquirer from "inquirer"
+import semafor from "semafor"
+import packager from "electron-packager"
+import path from "path"
 
-export default function interactive(verbose = true) {
-  
-  let log = semafor();
+export default function interactive() {
+  // Logging library.
+  const log = semafor()
 
-  let default_version = "0.30.4";
-  let default_src = process.cwd();
-  let default_out = glue([process.cwd(), "releases"]);
-  
-  let get_package_name = () => {
+  // Get the name from the package.json file.
+  function get_package_name() {
     try {
-      var pkg_path = glue([process.cwd(), "package.json"]);
-      var pkg = require(pkg_path);
-      return pkg.name;
-    }catch(e){}
-    return "";
+      const pkg = require(path.join(process.cwd(), "/package.json"))
+      return pkg.name
+    }
+    catch (e) {}
+    return ""
   }
 
-  let settings = {
-    dir: default_src,
-    name: null, 
+  // Default values for answers.
+  const settings = {
+    dir: process.cwd(),
+    name: get_package_name(),
     platform: "all",
     arch: "all",
-    version: default_version,
-    out: default_out,
+    version: "0.34.1",
+    out: path.join(process.cwd(), "/releases"),
     "app-bundle-id": "",
     "app-version": "",
     overwrite: true,
     asar: false
-  };
-
-  let error = (msg) => {
-    log.fail(msg.toString());
-    process.exit(1);
   }
 
-  let ask_overwrite = (cb) => {
-    let overwrite_prompt = {
-      type : 'confirm', 
-      name : "overwrite",
+  // Log and close the process.
+  function error(msg) {
+    log.fail(msg.toString().red)
+    process.exit(1)
+  }
+
+  // Start the cli.
+  inquirer.prompt([
+    {
+      type: "confirm",
+      name: "overwrite",
       message: "Overwrite output directory ?",
       default: true
-    }
-    inquirer.prompt(overwrite_prompt, (response) => {
-      cb(response.overwrite);
-    });
-  }
-
-  let ask_asar = (cb) => {
-    let asar_prompt = {
-      type : 'confirm', 
-      name : "asar",
+    },
+    {
+      type: "confirm",
+      name: "asar",
       message: "Use asar source packaging ?",
-      default: false
-    }
-    inquirer.prompt(asar_prompt, (response) => {
-      cb(response.asar);
-    });
-  }
-
-  let ask_sourcedir = (cb) => {
-    let sourcedir_prompt = {
-      type : 'input', 
-      name : "sourcedir",
+      default: settings.asar
+    },
+    {
+      type: "input",
+      name: "sourcedir",
       message: "Select Electron app source directory:",
-      default: default_src
-    }
-    inquirer.prompt(sourcedir_prompt, (response) => {
-      var sourcedir = response.sourcedir.trim();
-      if(sourcedir == "") {
-        sourcedir = default_src;
-      }
-      cb(sourcedir);
-    });
-  }
-
-  let ask_out = (cb) => {
-    let out_prompt = {
-      type : 'input', 
-      name : "out",
+      default: settings.dir
+    },
+    {
+      type: "input",
+      name: "out",
       message: "Select Electron app output directory:",
-      default: default_out
-    }
-    inquirer.prompt(out_prompt, (response) => {
-      var out = response.out.trim();
-      if(out == "") {
-        out = default_out;
-      }
-      cb(out);
-    });
-  }
-
-  let ask_appname = (cb) => {
-    let appname_prompt = {
-      type : 'input', 
-      name : "appname",
+      default: settings.out
+    },
+    {
+      type: "input",
+      name: "appname",
       message: "Select Application name:",
-      default: get_package_name()
-    }
-    inquirer.prompt(appname_prompt, (response) => {
-      var appname = response.appname.trim();
-      if(appname == "") {
-        error("Must provide the application name");
-        return;
-      }
-      cb(appname);
-    });
-  }
-
-  let ask_app_bundle_id = (cb) => {
-    let bundle_id_prompt = {
-      type : 'input', 
-      name : "bundle_id",
+      default: settings.name
+    },
+    {
+      type: "input",
+      name: "bundle_id",
       message: "Select App Bundle Id (optional):"
-    }
-    inquirer.prompt(bundle_id_prompt, (response) => {
-      cb(response.bundle_id);
-    });
-  }
-
-  let ask_app_version = (cb) => {
-    let app_version_prompt = {
-      type : 'input', 
-      name : "app_version",
+    },
+    {
+      type: "input",
+      name: "app_version",
       message: "Select App Version(optional):",
       default: "0.0.1"
-    }
-    inquirer.prompt(app_version_prompt, (response) => {
-      cb(response.app_version);
-    });
-  }
-
-  let ask_electron_version = (cb) => {
-    let version_prompt = {
-      type : 'input', 
-      name : "version",
+    },
+    {
+      type: "input",
+      name: "version",
       message: "Select Electron version release:",
-      default: default_version
-    }
-    inquirer.prompt(version_prompt, (response) => {
-      var version = response.version.trim();
-      if(version == "") {
-        version == default_version;  
-      }
-      cb(version);
-    });
-  }
-
-  let ask_arch = (cb) => {
-    let choices = ['all', 'ia32', 'x64'];
-    let arch_prompt = {
-      type : 'checkbox', 
-      name : "arch",
-      message: "Select architecture:",
-      choices: choices
-    }
-    inquirer.prompt(arch_prompt, (response) => {
-      let arch = response.arch; 
-      if(arch.length == 0) {
-        cb("all");
-        return;
-      }
-      if(arch.indexOf('all') != -1) {
-        cb("all");
-        return;
-      }
-      if(arch.indexOf('ia32') != -1 && 
-          arch.indexOf('x63') != -1) {
-        cb("all");
-        return;
-      }
-      cb(arch.join(","));
-    });
-  }
-
-  let ask_platform = (cb) => {
-    let choices = ['all', 'linux', 'darwin', 'win32'];
-    let platform_prompt = {
-      type : 'checkbox', 
-      name : "platforms",
+      default: settings.version
+    },
+    {
+      type: "checkbox",
+      name: "platform",
       message: "Select platforms:",
-      choices: choices
+      choices: ["all", "linux", "darwin", "win32"]
+    },
+    {
+      type: "checkbox",
+      name: "arch",
+      message: "Select architecture:",
+      choices: ["all", "ia32", "x64"]
     }
-    inquirer.prompt(platform_prompt, (response) => {
-      let platforms = response.platforms; 
-      if(platforms.length == 0) {
-        cb("all");
-        return;
-      }
-      if(platforms.indexOf('all') != -1) {
-        cb("all");
-        return;
-      }
-      if(platforms.indexOf('linux') != -1 && 
-          platforms.indexOf('darwin') != -1 &&
-          platforms.indexOf('win32') != -1) {
-        cb("all");
-        return;
-      }
-      cb(platforms.join(","));
-    });
-  }
-  
-  let run_electron_packager = (settings) => {
-    log.log("Electron packager settings:".white);
-    log.log(settings);
-    
+  ], answers => {
+    // Get the options and defaults.
+    const options = require("util")._extend(settings, answers)
+
+    // Fix two answers.
+    options.arch = answers.arch.join(",")
+    options.platform = answers.platform.join(",")
+
+    // Compile.
+    run_electron_packager(options)
+  })
+
+  function run_electron_packager(settings) {
+    log.log("Electron packager settings:".white)
+    log.log(settings)
+
     packager(settings, (err, appPath) => {
-      if(err) {
-        error(err);
-        return;
+      if (err) {
+        return error(err)
       }
-      log.ok("Application packaged successfuly!")
-      log.log(appPath);
-    });
+
+      log.ok(`Application packaged successfully to "${appPath}"`)
+    })
   }
-
-  ask_appname( (appname) => {
-    settings.name = appname;
-  ask_sourcedir( (src) => {
-    settings.dir = src;
-  ask_platform( (platforms) => {
-    settings.platform = platforms;
-  ask_arch( (arch) => {
-    settings.arch = arch;
-  ask_electron_version( (version) => {
-    settings.version = version;
-  ask_out( (out) => {
-    settings.out = out;
-  ask_overwrite( (overwrite) => {
-    settings.overwrite = overwrite;
-  ask_asar( (asar) => {
-    settings.asar = asar;
-  ask_app_bundle_id( (bundle_id) => {
-    settings["app-bundle-id"] = bundle_id;
-  ask_app_version( (app_version) => {
-    settings["app-version"] = app_version;
-
-  run_electron_packager(settings);
-  
-  })})})})})})})})})}); // <- this is ugly
-
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-packager-interactive",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "An interactive implementation of electron-packager",
   "main": "cli.js",
   "scripts": {
@@ -34,14 +34,13 @@
   "dependencies": {
     "colors": "^1.1.2",
     "electron-packager": "^5.0.2",
-    "glue-path": "0.0.4",
     "inquirer": "^0.9.0",
     "semafor": "0.0.1"
   },
   "devDependencies": {
     "babel": "^5.8.21",
-    "grunt": "^0.4.5",
     "grunt-babel": "^5.0.1",
+    "grunt-cli": "^0.1.13",
     "load-grunt-tasks": "^3.2.0"
   }
 }


### PR DESCRIPTION
Tidied up the code, ES6 doesn't have to be `let` and `() =. {}`-ed everywhere :smile_cat:   
Removed semi-colons, honestly they're not needed :hear_no_evil:  
Use interpolated strings instead of whole packages for clarity, no idea what that lib was doing. :confounded:   
Fixed a common mistake with `grunt` and `grunt-cli` packages. :performing_arts: