### PR TITLE
Add some auto defaults + updated electron version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,27 @@ export default function interactive () {
     }
   }
 
+  function getPackageVersion () {
+    try {
+      const pkg = require(path.join(process.cwd(), 'package.json'))
+      return pkg.version
+    } catch (e) {
+      return '0.0.1'
+    }
+  }
+
+  function getElectronVersion () {
+    try {
+      const pkg = require(path.join(process.cwd(), 'package.json'))
+      let fin 
+      if(fin.dependencies && fin.dependencies.electron) fin = fin.dependencies.electron
+      if(fin.devDependencies && fin.devDependencies.electron) fin = fin.devDependencies.electron
+      return fin
+    } catch (e) {
+      return '7.1.5'
+    }
+  }
+
   function runElectronPackager (settings) {
     log.log('Electron packager settings:')
     log.log(settings)
@@ -35,7 +56,9 @@ export default function interactive () {
     name: getPackageName(),
     platform: 'all',
     arch: 'all',
-    electronVersion: '1.6.15',
+    electronVersion: getElectronVersion(),
+    version: getPackageVersion(),
+    defaultIcon: path.join(process.cwd(), 'assets', 'icon.ico'),
     out: path.join(process.cwd(), 'releases'),
     'appBundleId': '',
     'appVersion': '',
@@ -91,12 +114,13 @@ export default function interactive () {
       type: 'input',
       name: 'appVersion',
       message: 'Select App Version(optional):',
-      default: '0.0.1'
+      default: settings.version
     },
     {
       type: 'input',
       name: 'icon',
-      message: 'Select Electron icon file:'
+      message: 'Select Electron icon file:',
+      default: settings.defaultIcon
     },
     {
       type: 'input',


### PR DESCRIPTION
This should work but I haven't tested it.
Basically it adds some features which make using this easier.
Added a dynamic Electron Version by seeing if its in dependencies, dev dependencies and falling back to v7.1.5.
Added a dynamic version check by using the version in the package.json falling back to v0.0.1.
Added a default icon file, which is where I store my icon as well as I've seen someone else do so. This change is more for my convenience but it is a smart place to save your icon.